### PR TITLE
Finalize Data Structure and create A21.py

### DIFF
--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -98,3 +98,25 @@ The data for the pressure drop calculator will be input in the following manner:
 ```
 
 As these components are input, they should be assigned a unique index identification number (IIN) that tells the program which step this is. A parent/child value should also be appended somewhere (look at [issue #7](https://github.com/louvill/AAE535dPCalc/issues/7) for more info)
+
+# .json output format
+This last section details how the file type will look when it is output by MAIN.py and sent back to electron to be presented to the user. The 'components' dictionary will output the pressure drop along every single component including their Index Identification Number (IIN) and the Component ID (CID). After all of the components have been output, the final value will be the total pressure drop of the system.
+
+```javascript
+{
+	"components" : [
+	  {
+	    "IIN" : IIN1,
+		"CID" : CID1,
+		"pressureDrop" : deltaP1
+	  },
+	  {
+	    "IIN" : IIN2,
+		"CID" : CID2,
+		"pressureDrop" : deltaP2
+	  }
+	  // This will continue for all of the components of the system
+	],
+	"pressureDropSum" : sumDeltaP
+}
+```

--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -2,6 +2,7 @@
 
 The data for the pressure drop calculator will be input in the following manner:
 
+
 ### Python file format
 ```python
 {

--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -1,6 +1,6 @@
 ## Finalized Input Data format
 
-The data for the pressure drop calculator will be input in the following stucture:
+The data for the pressure drop calculator will be input in the following stuctures:
 
 ### Python file format
 ```python

--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -1,6 +1,6 @@
 ## Finalized Input Data format
 
-The data for the pressure drop calculator will be input in the following stuctures:
+The data for the pressure drop calculator will be input in the following manner:
 
 ### Python file format
 ```python

--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -4,49 +4,85 @@ The data for the pressure drop calculator will be input in the following manner:
 
 ### Python file format
 ```python
-[
-  CID, 
-  ['deltaX', 'deltaZ','radius','angle'],
-  ['insideArea','massFlow','D_h'],
-  ['valveCoefficient','specificGravity','N'],
-  ['upstreamArea','downstreamArea','contractionType (a or c)',['contractionParameters']]
-  ['rho', 'mu', 'T'],
-  ['rey', 'f','kt', 'deltaP']
-]
+{
+  'CID' : CID,
+  'geometry' : {
+    'length' : deltaX,
+	'height' : deltaZ,
+	'insideArea' : Ainside,
+	'massFlow' : mDot,
+	'hydraulicDiameter' : Dh,
+	'bendRadius' : radius,
+	'bendAngle' : angle
+  },
+  'valve' : {
+    'valveCoefficient' : cValve,
+	'specificGravity' : rhoSpec,
+	'valveAuthority' : N,
+  },
+  'misc' : {
+    'upstreamArea' : upsteamArea,
+	'downstreamArea' : downstreamArea,
+	'contractionAngledOrCurved' : 'a or c',
+	'contractionParameters' : {
+	  'angle' : contractAngle,
+	  'downstreamDiameter' : contractDiam,
+	  'downstreamRadiusOfCurvature' : contractCurvRad
+    }
+  },
+  'fluidProperties' : {
+    'density' = rho,
+	'viscosity' = mu,
+	'temperature' = T
+  },
+  'calculated' : {
+    'reynolds' : rey,
+	'frictionFactor' : f,
+	'ktLosses' : kt,
+	'pressureDrop' : deltaP
+  }
+}
 ```
 
 ### .json/JavaScript file format
 ```javascript
 {
-  "componentID": CID,
-  "distanceValues": [
+  "CID": CID,
+  "geometry": [
     {
-      "lengthChange" : deltaX,
-      "altitudeChange" : deltaZ,
+      "length" : deltaX,
+      "height" : deltaZ,
+	  "insideArea" : Ainside,
+	  "massFlow" : mDot,
+	  "hydraulicDiameter" : Dh,
       "bendRadius" : radius,
       "bendAngle" : angle
     }
   ],
-  "miscInfo" : [
+  "valve" : {
+    "valveCoefficient" : cValve,
+	"specificGravity" : rhoSpec,
+	"valveAuthority" : N,
+  },
+  "misc" : [
     {
-      "valveCoefficient" : valveCoefficient,
       "contractExpandUpstream" : upsteamArea,
       "contractExpandDownstream" : downstreamArea,
-      "contractionAngledOrCurved" : expandType,
+      "contractionAngledOrCurved" : 'a or c',
       "contractionParameters" : [
         {
           "angle" : contractAngle,
-          "downstreamDiameter" : contractDiameter,
-          "downstreamRadiusOfCurvature" : contractRadius
+          "downstreamDiameter" : contractDiam,
+          "downstreamRadiusOfCurvature" : contractCurvRad
         }
       ]
     }
   ],
   "fluidProperties" : [
     {
-      "fluidDensity" : rho,
-      "fluidViscosity" : mu,
-      "fluidTemperature" : T
+      "density" : rho,
+      "viscosity" : mu,
+      "temperature" : T
     }
   ],
   "calculatedTerms" : [
@@ -54,7 +90,7 @@ The data for the pressure drop calculator will be input in the following manner:
       "reynoldsNumber" : rey,
       "frictionFactor" : f,
       "ktLosses" : kt,
-      "pressureLoss" : deltaP
+      "pressureDrop" : deltaP
     }
   ]
 }

--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -1,0 +1,62 @@
+## Finalized Input Data format
+
+The data for the pressure drop calculator will be input in the following stucture:
+
+### Python file format
+```python
+[
+  CID, 
+  ['deltaX', 'deltaZ','radius','angle'],
+  ['insideArea','massFlow','D_h',],
+  ['valveCoefficient','upstreamArea','downstreamArea','contractionType (a or c)', ['contractionParameters']]
+  ['rho', 'mu', 'T'],
+  ['rey', 'f','kt', 'deltaP']
+]
+```
+
+### .json/JavaScript file format
+```javascript
+{
+  "componentID": CID,
+  "distanceValues": [
+    {
+      "lengthChange" : deltaX,
+      "altitudeChange" : deltaZ,
+      "bendRadius" : radius,
+      "bendAngle" : angle
+    }
+  ],
+  "miscInfo" : [
+    {
+      "valveCoefficient" : valveCoefficient,
+      "contractExpandUpstream" : upsteamArea,
+      "contractExpandDownstream" : downstreamArea,
+      "contractionAngledOrCurved" : expandType,
+      "contractionParameters" : [
+        {
+          "angle" : contractAngle,
+          "downstreamDiameter" : contractDiameter,
+          "downstreamRadiusOfCurvature" : contractRadius
+        }
+      ]
+    }
+  ],
+  "fluidProperties" : [
+    {
+      "fluidDensity" : rho,
+      "fluidViscosity" : mu,
+      "fluidTemperature" : T
+    }
+  ],
+  "calculatedTerms" : [
+    {
+      "reynoldsNumber" : rey,
+      "frictionFactor" : f,
+      "ktLosses" : kt,
+      "pressureLoss" : deltaP
+    }
+  ]
+}
+```
+
+As these components are input, they should be assigned a unique index identification number (IIN) that tells the program which step this is. A parent/child value should also be appended somewhere (look at [issue #7](https://github.com/louvill/AAE535dPCalc/issues/7) for more info)

--- a/SysEng/dataInputFormat.md
+++ b/SysEng/dataInputFormat.md
@@ -7,8 +7,9 @@ The data for the pressure drop calculator will be input in the following stuctur
 [
   CID, 
   ['deltaX', 'deltaZ','radius','angle'],
-  ['insideArea','massFlow','D_h',],
-  ['valveCoefficient','upstreamArea','downstreamArea','contractionType (a or c)', ['contractionParameters']]
+  ['insideArea','massFlow','D_h'],
+  ['valveCoefficient','specificGravity','N'],
+  ['upstreamArea','downstreamArea','contractionType (a or c)',['contractionParameters']]
   ['rho', 'mu', 'T'],
   ['rey', 'f','kt', 'deltaP']
 ]

--- a/bin/A21.py
+++ b/bin/A21.py
@@ -1,0 +1,17 @@
+#Using the alternative method from Issue #7
+#def A21Func():
+
+
+data = {'line': [['deltaX','deltaZ'],
+                 ['insideArea','mass flow','D_h'],
+                 ['rho','mu','T'],
+                 ['Rey','f','deltaP']
+                 ],
+        'bend': [['deltaX','deltaZ'],
+                 ['insideArea','mass flow','D_h','radius','angle'],
+                 ['rho','mu','T'],
+                 ['Rey','f','deltaP']
+                 ]
+        }
+
+print(data['line'][0])

--- a/bin/A21.py
+++ b/bin/A21.py
@@ -1,17 +1,90 @@
 #Using the alternative method from Issue #7
 #def A21Func():
+#Values that are not required for a component are set to False
+# This allows the loop to only require numbers that DON'T have
+# False as their value.
 
-
-data = {'line': [['deltaX','deltaZ'],
-                 ['insideArea','mass flow','D_h'],
-                 ['rho','mu','T'],
-                 ['Rey','f','deltaP']
+cTypes = {
+    'line': ['LNE',
+             ['deltaX','deltaZ',False, False],
+             ['insideArea','mass flow','D_h'],
+             False, #no valve parameters
+             False, #not contraction/expansion
+             ['rho','mu','T'],
+             ['Rey','f',False,'deltaP']
+             ],
+    'bend': ['BND',
+             ['deltaX','deltaZ','radius', 'angle'],
+             ['insideArea','mass flow','D_h'],
+             False, #not a valve
+             False, #not contraction/expansion
+             ['rho','mu','T'],
+             ['Rey','f','kt','deltaP']
+             ],
+    'valve': ['VLV',
+              False, #no distance
+              False, #no component dimensions
+              ['valveCoefficient','specificGravity','N'],
+              False, #not contraction/expansion
+              False, #no fluid properties required
+              [False,False,False, 'deltaP']
+              ],
+    'tubeSplit' : ['SPL',
+                   ['deltaX', 'deltaZ',False,False],
+                   ['insideArea','massFlow','D_h',],
+                   False, #Not a valve
+                   False, #Not Contraction/Expansion
+                   ['rho', 'mu', 'T'],
+                   ['rey', 'f','kt', 'deltaP']
+                   ],
+    'tubeJoin' : ['JON',
+                  ['deltaX', 'deltaZ',False,False],
+                  ['insideArea','massFlow','D_h',],
+                  False, #Not a valve
+                  False, #Not Contraction/Expansion
+                  ['rho', 'mu', 'T'],
+                  ['rey', 'f','kt', 'deltaP']
+                  ],
+    'suddenExpansion' : ['EXP',
+                         False, #Don't need distances
+                         [False,'massFlow',False,],
+                         False, #Not a valve
+                         ['upstreamArea','downstreamArea',False,False],
+                         ['rho', 'mu', 'T'],
+                         ['rey', 'f','kt', 'deltaP']
+                         ],
+    'suddenContraction' : ['CON',
+                           False, #Don't need distances
+                           [False,'massFlow',False,],
+                           False, #Not a valve
+                           ['upstreamArea','downstreamArea','contractionType (a or c)',['contractionParameters']],
+                           ['rho', 'mu', 'T'],
+                           ['rey', 'f','kt', 'deltaP']
+                           ]
+    #The next three will be odd for calculating pressure drop for them.
+    # They will (probably) not use the typical values herein.
+    'orifice' : ['ORF',
+                 False,
+                 False,
+                 False,
+                 False,
+                 False,
+                 False,
                  ],
-        'bend': [['deltaX','deltaZ'],
-                 ['insideArea','mass flow','D_h','radius','angle'],
-                 ['rho','mu','T'],
-                 ['Rey','f','deltaP']
-                 ]
-        }
-
-print(data['line'][0])
+    'injector' : ['INJ',
+                  False,
+                  False,
+                  False,
+                  False,
+                  False,
+                  False,
+                  ],
+    'catalystBed' : ['BED',
+                     False,
+                     False,
+                     False,
+                     False,
+                     False,
+                     False,
+                     ]
+}

--- a/bin/A21.py
+++ b/bin/A21.py
@@ -4,6 +4,9 @@
 # This allows the loop to only require numbers that DON'T have
 # False as their value.
 
+#These dictionaries should be able to looped through by doing recursion.
+# see recursionExample.py in /bin/ for an example of this.
+
 cTypes = {
     #LINE DEFINITION
     'line': {

--- a/bin/A21.py
+++ b/bin/A21.py
@@ -1,5 +1,11 @@
 #Using the alternative method from Issue #7
-#def A21Func():
+#
+#This function will input the name of the component type and output a full
+# dictionary that can then be filled with values for the actual computation
+# of the pressure drop. The input can be in lower case, upper case, or a mixture
+# and the program should be able to find it. Alternative names are not programmed
+# in yet, so be careful with how you type things.
+#
 #Values that are not required for a component are set to False
 # This allows the loop to only require numbers that DON'T have
 # False as their value.
@@ -9,7 +15,7 @@
 
 cTypes = {
     #LINE DEFINITION
-    'line': {
+    'LINE': {
       'CID' : 'LNE',
       'geometry' : {
         'length' : 'deltaX',
@@ -48,7 +54,7 @@ cTypes = {
       }
     },
     #BEND DEFINITION
-    'bend': {
+    'BEND': {
       'CID' : 'BND',
       'geometry' : {
         'length' : 'deltaX',
@@ -87,7 +93,7 @@ cTypes = {
       }
     },
     #VALVE DEFINITION
-    'valve': {
+    'VALVE': {
       'CID' : 'VLV',
       'geometry' : {
         'length' : False,
@@ -126,7 +132,7 @@ cTypes = {
       }
     },
     #TUBE SPLIT DEFINITION
-    'tubeSplit' : {
+    'TUBESPLIT' : {
       'CID' : 'SPL',
       'geometry' : {
         'length' : False,
@@ -165,7 +171,7 @@ cTypes = {
       }
     },
     #TUBE JOIN DEFINITION
-    'tubeJoin' : {
+    'TUBEJOIN' : {
       'CID' : 'JON',
       'geometry' : {
         'length' : False,
@@ -204,7 +210,7 @@ cTypes = {
       }
     },
     #SUDDEN EXPANSION DEFINITION
-    'suddenExpansion' : {
+    'SUDDENEXPANSION' : {
       'CID' : 'EXP',
       'geometry' : {
         'length' : False,
@@ -243,7 +249,7 @@ cTypes = {
       }
     },
     #SUDDEN CONTRACTION DEFINITION
-    'suddenContraction' : {
+    'SUDDENCONTRACTION' : {
       'CID' : 'CON',
       'geometry' : False,
       'valve' : {
@@ -278,7 +284,7 @@ cTypes = {
     # They will (probably) not use the typical values herein.          #
     ####################################################################
     #ORIFICE
-    'orifice' : {
+    'ORIFICE' : {
       'CID' : 'ORF',
       'geometry' : {
         'length' : False,
@@ -317,7 +323,7 @@ cTypes = {
       }
     },
     #INJECTOR
-    'injector' : {
+    'INJECTOR' : {
       'CID' : 'INJ',
       'geometry' : {
         'length' : False,
@@ -356,7 +362,7 @@ cTypes = {
       }
     },
     #CATALYST BED
-    'catalystBed' : {
+    'CATALYSTBED' : {
       'CID' : 'CAT',
       'geometry' : {
         'length' : False,
@@ -395,3 +401,20 @@ cTypes = {
       }
     },
 }
+
+########################################
+# Now time for the function defintion  #
+########################################
+def A21(name):
+    upperName = str(name).upper()
+    try:
+        parameters = cTypes[upperName]
+    except KeyError:
+        raise KeyError("You have not input a valid component type. "+
+                   "Look at the documentation to see what names"+
+                   " have been assigned to which components.")
+    else:
+        return(parameters)
+
+#Example of this in use. Uncomment to see what happens and try some names out yourself
+#print(A21('line'))

--- a/bin/A21.py
+++ b/bin/A21.py
@@ -10,7 +10,7 @@
 cTypes = {
     #LINE DEFINITION
     'line': {
-      'CID' : CID,
+      'CID' : 'LNE',
       'geometry' : {
         'length' : 'deltaX',
         'height' : 'deltaZ',
@@ -36,9 +36,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = 'rho',
-        'viscosity' = 'mu',
-        'temperature' = 'T'
+        'density' : 'rho',
+        'viscosity' : 'mu',
+        'temperature' : 'T'
       },
       'calculated' : {
         'reynolds' : 'rey',
@@ -49,7 +49,7 @@ cTypes = {
     },
     #BEND DEFINITION
     'bend': {
-      'CID' : 'BND,
+      'CID' : 'BND',
       'geometry' : {
         'length' : 'deltaX',
         'height' : 'deltaZ',
@@ -75,9 +75,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = 'rho',
-        'viscosity' = 'mu',
-        'temperature' = 'T'
+        'density' : 'rho',
+        'viscosity' : 'mu',
+        'temperature' : 'T'
       },
       'calculated' : {
         'reynolds' : 'rey',
@@ -88,7 +88,7 @@ cTypes = {
     },
     #VALVE DEFINITION
     'valve': {
-      'CID' : 'VLV,
+      'CID' : 'VLV',
       'geometry' : {
         'length' : False,
         'height' : False,
@@ -114,9 +114,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = False,
-        'viscosity' = False,
-        'temperature' = False
+        'density' : False,
+        'viscosity' : False,
+        'temperature' : False
       },
       'calculated' : {
         'reynolds' : False,
@@ -153,9 +153,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = 'rho',
-        'viscosity' = 'mu',
-        'temperature' = 'T'
+        'density' : 'rho',
+        'viscosity' : 'mu',
+        'temperature' : 'T'
       },
       'calculated' : {
         'reynolds' : 'rey',
@@ -192,9 +192,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = 'rho',
-        'viscosity' = 'mu',
-        'temperature' = 'T'
+        'density' : 'rho',
+        'viscosity' : 'mu',
+        'temperature' : 'T'
       },
       'calculated' : {
         'reynolds' : 'rey',
@@ -205,7 +205,7 @@ cTypes = {
     },
     #SUDDEN EXPANSION DEFINITION
     'suddenExpansion' : {
-      'CID' : CID,
+      'CID' : 'EXP',
       'geometry' : {
         'length' : False,
         'height' : False,
@@ -231,9 +231,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = 'rho',
-        'viscosity' = 'mu',
-        'temperature' = 'T'
+        'density' : 'rho',
+        'viscosity' : 'mu',
+        'temperature' : 'T'
       },
       'calculated' : {
         'reynolds' : 'rey',
@@ -262,9 +262,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = 'rho',
-        'viscosity' = 'mu',
-        'temperature' = 'T'
+        'density' : 'rho',
+        'viscosity' : 'mu',
+        'temperature' : 'T'
       },
       'calculated' : {
         'reynolds' : False,
@@ -305,9 +305,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = False,
-        'viscosity' = False,
-        'temperature' = False
+        'density' : False,
+        'viscosity' : False,
+        'temperature' : False
       },
       'calculated' : {
         'reynolds' : False,
@@ -318,7 +318,7 @@ cTypes = {
     },
     #INJECTOR
     'injector' : {
-      'CID' : 'ORF',
+      'CID' : 'INJ',
       'geometry' : {
         'length' : False,
         'height' : False,
@@ -344,9 +344,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = False,
-        'viscosity' = False,
-        'temperature' = False
+        'density' : False,
+        'viscosity' : False,
+        'temperature' : False
       },
       'calculated' : {
         'reynolds' : False,
@@ -357,7 +357,7 @@ cTypes = {
     },
     #CATALYST BED
     'catalystBed' : {
-      'CID' : 'ORF',
+      'CID' : 'CAT',
       'geometry' : {
         'length' : False,
         'height' : False,
@@ -383,9 +383,9 @@ cTypes = {
         }
       },
       'fluidProperties' : {
-        'density' = False,
-        'viscosity' = False,
-        'temperature' = False
+        'density' : False,
+        'viscosity' : False,
+        'temperature' : False
       },
       'calculated' : {
         'reynolds' : False,

--- a/bin/A21.py
+++ b/bin/A21.py
@@ -5,86 +5,390 @@
 # False as their value.
 
 cTypes = {
-    'line': ['LNE',
-             ['deltaX','deltaZ',False, False],
-             ['insideArea','mass flow','D_h'],
-             False, #no valve parameters
-             False, #not contraction/expansion
-             ['rho','mu','T'],
-             ['Rey','f',False,'deltaP']
-             ],
-    'bend': ['BND',
-             ['deltaX','deltaZ','radius', 'angle'],
-             ['insideArea','mass flow','D_h'],
-             False, #not a valve
-             False, #not contraction/expansion
-             ['rho','mu','T'],
-             ['Rey','f','kt','deltaP']
-             ],
-    'valve': ['VLV',
-              False, #no distance
-              False, #no component dimensions
-              ['valveCoefficient','specificGravity','N'],
-              False, #not contraction/expansion
-              False, #no fluid properties required
-              [False,False,False, 'deltaP']
-              ],
-    'tubeSplit' : ['SPL',
-                   ['deltaX', 'deltaZ',False,False],
-                   ['insideArea','massFlow','D_h',],
-                   False, #Not a valve
-                   False, #Not Contraction/Expansion
-                   ['rho', 'mu', 'T'],
-                   ['rey', 'f','kt', 'deltaP']
-                   ],
-    'tubeJoin' : ['JON',
-                  ['deltaX', 'deltaZ',False,False],
-                  ['insideArea','massFlow','D_h',],
-                  False, #Not a valve
-                  False, #Not Contraction/Expansion
-                  ['rho', 'mu', 'T'],
-                  ['rey', 'f','kt', 'deltaP']
-                  ],
-    'suddenExpansion' : ['EXP',
-                         False, #Don't need distances
-                         [False,'massFlow',False,],
-                         False, #Not a valve
-                         ['upstreamArea','downstreamArea',False,False],
-                         ['rho', 'mu', 'T'],
-                         ['rey', 'f','kt', 'deltaP']
-                         ],
-    'suddenContraction' : ['CON',
-                           False, #Don't need distances
-                           [False,'massFlow',False,],
-                           False, #Not a valve
-                           ['upstreamArea','downstreamArea','contractionType (a or c)',['contractionParameters']],
-                           ['rho', 'mu', 'T'],
-                           ['rey', 'f','kt', 'deltaP']
-                           ]
-    #The next three will be odd for calculating pressure drop for them.
-    # They will (probably) not use the typical values herein.
-    'orifice' : ['ORF',
-                 False,
-                 False,
-                 False,
-                 False,
-                 False,
-                 False,
-                 ],
-    'injector' : ['INJ',
-                  False,
-                  False,
-                  False,
-                  False,
-                  False,
-                  False,
-                  ],
-    'catalystBed' : ['BED',
-                     False,
-                     False,
-                     False,
-                     False,
-                     False,
-                     False,
-                     ]
+    #LINE DEFINITION
+    'line': {
+      'CID' : CID,
+      'geometry' : {
+        'length' : 'deltaX',
+        'height' : 'deltaZ',
+        'insideArea' : 'insideArea',
+        'massFlow' : 'mDot',
+        'hydraulicDiameter' : 'Dh',
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = 'rho',
+        'viscosity' = 'mu',
+        'temperature' = 'T'
+      },
+      'calculated' : {
+        'reynolds' : 'rey',
+        'frictionFactor' : 'f',
+        'ktLosses' : False,
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #BEND DEFINITION
+    'bend': {
+      'CID' : 'BND,
+      'geometry' : {
+        'length' : 'deltaX',
+        'height' : 'deltaZ',
+        'insideArea' : 'insideArea',
+        'massFlow' : 'mDot',
+        'hydraulicDiameter' : 'Dh',
+        'bendRadius' : 'radius',
+        'bendAngle' : 'angle'
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = 'rho',
+        'viscosity' = 'mu',
+        'temperature' = 'T'
+      },
+      'calculated' : {
+        'reynolds' : 'rey',
+        'frictionFactor' : 'f',
+        'ktLosses' : 'kt',
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #VALVE DEFINITION
+    'valve': {
+      'CID' : 'VLV,
+      'geometry' : {
+        'length' : False,
+        'height' : False,
+        'insideArea' : False,
+        'massFlow' : False,
+        'hydraulicDiameter' : False,
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : 'cValve',
+        'specificGravity' : 'rhoSpec',
+        'valveAuthority' : 'N'
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = False,
+        'viscosity' = False,
+        'temperature' = False
+      },
+      'calculated' : {
+        'reynolds' : False,
+        'frictionFactor' : False,
+        'ktLosses' : False,
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #TUBE SPLIT DEFINITION
+    'tubeSplit' : {
+      'CID' : 'SPL',
+      'geometry' : {
+        'length' : False,
+        'height' : 'deltaZ',
+        'insideArea' : 'insideArea',
+        'massFlow' : 'mDot',
+        'hydraulicDiameter' : 'Dh',
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = 'rho',
+        'viscosity' = 'mu',
+        'temperature' = 'T'
+      },
+      'calculated' : {
+        'reynolds' : 'rey',
+        'frictionFactor' : 'f',
+        'ktLosses' : 'kt',
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #TUBE JOIN DEFINITION
+    'tubeJoin' : {
+      'CID' : 'JON',
+      'geometry' : {
+        'length' : False,
+        'height' : 'deltaZ',
+        'insideArea' : 'insideArea',
+        'massFlow' : 'mDot',
+        'hydraulicDiameter' : 'Dh',
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = 'rho',
+        'viscosity' = 'mu',
+        'temperature' = 'T'
+      },
+      'calculated' : {
+        'reynolds' : 'rey',
+        'frictionFactor' : 'f',
+        'ktLosses' : 'kt',
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #SUDDEN EXPANSION DEFINITION
+    'suddenExpansion' : {
+      'CID' : CID,
+      'geometry' : {
+        'length' : False,
+        'height' : False,
+        'insideArea' : False,
+        'massFlow' : False,
+        'hydraulicDiameter' : False,
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : 'upsteamArea',
+        'downstreamArea' : 'downstreamArea',
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = 'rho',
+        'viscosity' = 'mu',
+        'temperature' = 'T'
+      },
+      'calculated' : {
+        'reynolds' : 'rey',
+        'frictionFactor' : 'f',
+        'ktLosses' : 'kt',
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #SUDDEN CONTRACTION DEFINITION
+    'suddenContraction' : {
+      'CID' : 'CON',
+      'geometry' : False,
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : 'upsteamArea',
+        'downstreamArea' : 'downstreamArea',
+        'contractionAngledOrCurved' : 'a or c',
+        'contractionParameters' : {
+            'angle' : 'contractAngle',
+            'downstreamDiameter' : 'contractDiam',
+            'downstreamRadiusOfCurvature' : 'contractCurvRad'
+        }
+      },
+      'fluidProperties' : {
+        'density' = 'rho',
+        'viscosity' = 'mu',
+        'temperature' = 'T'
+      },
+      'calculated' : {
+        'reynolds' : False,
+        'frictionFactor' : False,
+        'ktLosses' : False,
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    ####################################################################
+    #The next three will be odd for calculating pressure drop for them.#
+    # They will (probably) not use the typical values herein.          #
+    ####################################################################
+    #ORIFICE
+    'orifice' : {
+      'CID' : 'ORF',
+      'geometry' : {
+        'length' : False,
+        'height' : False,
+        'insideArea' : False,
+        'massFlow' : False,
+        'hydraulicDiameter' : False,
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = False,
+        'viscosity' = False,
+        'temperature' = False
+      },
+      'calculated' : {
+        'reynolds' : False,
+        'frictionFactor' : False,
+        'ktLosses' : False,
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #INJECTOR
+    'injector' : {
+      'CID' : 'ORF',
+      'geometry' : {
+        'length' : False,
+        'height' : False,
+        'insideArea' : False,
+        'massFlow' : False,
+        'hydraulicDiameter' : False,
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = False,
+        'viscosity' = False,
+        'temperature' = False
+      },
+      'calculated' : {
+        'reynolds' : False,
+        'frictionFactor' : False,
+        'ktLosses' : False,
+        'pressureDrop' : 'deltaP'
+      }
+    },
+    #CATALYST BED
+    'catalystBed' : {
+      'CID' : 'ORF',
+      'geometry' : {
+        'length' : False,
+        'height' : False,
+        'insideArea' : False,
+        'massFlow' : False,
+        'hydraulicDiameter' : False,
+        'bendRadius' : False,
+        'bendAngle' : False
+      },
+      'valve' : {
+        'valveCoefficient' : False,
+        'specificGravity' : False,
+        'valveAuthority' : False
+      },
+      'misc' : {
+        'upstreamArea' : False,
+        'downstreamArea' : False,
+        'contractionAngledOrCurved' : False,
+        'contractionParameters' : {
+            'angle' : False,
+            'downstreamDiameter' : False,
+            'downstreamRadiusOfCurvature' : False
+        }
+      },
+      'fluidProperties' : {
+        'density' = False,
+        'viscosity' = False,
+        'temperature' = False
+      },
+      'calculated' : {
+        'reynolds' : False,
+        'frictionFactor' : False,
+        'ktLosses' : False,
+        'pressureDrop' : 'deltaP'
+      }
+    },
 }

--- a/bin/recusionExample.py
+++ b/bin/recusionExample.py
@@ -1,0 +1,34 @@
+#This is a recursive test. We have a dictionary of dictionaries and we
+# need to get every single value in this dictionaries of dictionaries
+# that doesn't read false. The 'iterdict' function below recursively
+# goes through every dictionary and finds the values we need (both the
+# number, and the label).
+
+#Play with this a bit! See if you can break something or if you can
+# make it work for even super complicated structures
+
+test = {
+    '1' : 1,
+    '2' : {
+        '2.1' : 2.1,
+        '2.2' : {
+            '2.21' : 2.21,
+            '2.22' : False,
+            '2.23' : 2.23
+            },
+        '2.3' : False
+        },
+    '3' : {
+        '3.1' : 3.1,
+        '3.2' : False
+        },
+    '4' : 4
+    }
+def iterdict(d):
+    for k,v in d.items():
+        if isinstance(v, dict):
+            iterdict(v)
+        else:
+            if v:
+                print(str(k+':'+str(v)))
+iterdict(test)


### PR DESCRIPTION
#### Summary
SUMMARY: Features "Create A21 and finalize the input data structure"

#### Purpose of change
This is the creation of the A21 method to store all of the info from #4 into python. This pull request closes #13, closes #7, closes #4, and since A12 is being absorbed within this also closes #6.

#### Describe the solution
I've built a dictionary within Python where each thing can be called by name. I may eventually change this to allow for calling by component ID or by name. This also finalizes issue #4 since this will need to be completed before A21 can be fully programmed.

#### Describe alternatives you've considered
Rather than a dictionary, it could have been a giant array, but that seemed a bit bulky to work with and indexing would be a nightmare. Instead, the library set up allows us to call information in the following way:
```python
#input 
data['geometry']['length']

#output
2.34 #the length of the piece
```

#### Testing
Testing has included basic syntax sweep-through and the testing of the names to ensure the proper dictionaries are being output with the correct name.

#### Additional context
Let me know any feedback for A21. It should hopefully be the only location we need to have this HUGE of a dictionary. Everything else after this point should just be calling information from this and then plugging in numbers into it.